### PR TITLE
Initial version of bumpdeps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:11
+COPY . /bumpdeps
+RUN /bumpdeps/gradlew --no-daemon -p /bumpdeps installDist
+ENTRYPOINT ["/bumpdeps/build/install/bumpdeps/bin/bumpdeps"]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,40 @@
+name: 'Bump Spinnaker Dependencies'
+description: 'Bump dependencies in external repositories upon a release'
+inputs:
+  ref:
+    description: 'the release ref triggering this dependency bump'
+    required: true
+  key:
+    description: 'the key in gradle.properties to modify'
+    required: true
+  repositories:
+    description: 'the comma-separated list of repository names to modify'
+    required: true
+  repoOwner:
+    description: 'the owner of the repositories to modify'
+    required: true
+    default: spinnakerbot
+  upstreamOwner:
+    description: 'the owner of the repositories to send pull requests to'
+    required: true
+    default: spinnaker
+  reviewers:
+    description: "the comma-separated list of reviewers (prefixed with 'team:' for a team) for the pull request"
+    required: true
+    default: 'team:oss-reviewers'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+  - '--ref'
+  - ${{ inputs.ref }}
+  - '--key'
+  - ${{ inputs.key }}
+  - '--repositories'
+  - ${{ inputs.repositories }}
+  - '--repo-owner'
+  - ${{ inputs.repoOwner }}
+  - '--upstream-owner'
+  - ${{ inputs.upstreamOwner }}
+  - '--reviewers'
+  - ${{ inputs.reviewers }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    val kotlinVersion = "1.3.71"
+    kotlin("jvm") version kotlinVersion
+    id("org.jlleitschuh.gradle.ktlint") version "9.2.1"
+    application
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+}
+
+dependencies {
+    implementation("com.github.ajalt:clikt:2.5.0")
+    implementation("io.github.microutils:kotlin-logging:1.7.8")
+    implementation("org.eclipse.jgit:org.eclipse.jgit:5.7.0.202003110725-r")
+    implementation("org.kohsuke:github-api:1.109")
+    implementation("nu.studer:java-ordered-properties:1.0.2")
+
+    runtimeOnly("org.slf4j:slf4j-simple:1.7.30")
+}
+
+application {
+    mainClassName = "io.spinnaker.bumpdeps.MainKt"
+}
+
+ktlint {
+    enableExperimentalRules.set(true)
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions.jvmTarget = "11"
+}

--- a/src/main/kotlin/io/spinnaker/bumpdeps/Main.kt
+++ b/src/main/kotlin/io/spinnaker/bumpdeps/Main.kt
@@ -1,0 +1,216 @@
+package io.spinnaker.bumpdeps
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.split
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import kotlin.system.exitProcess
+import mu.KotlinLogging
+import nu.studer.java.util.OrderedProperties.OrderedPropertiesBuilder
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.transport.RefSpec
+import org.eclipse.jgit.transport.URIish
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
+import org.kohsuke.github.GHIssueState
+import org.kohsuke.github.GitHubBuilder
+
+class BumpDeps : CliktCommand() {
+
+    private val logger = KotlinLogging.logger {}
+
+    companion object {
+        val REF_PREFIX = "refs/tags/v"
+        const val GITHUB_OAUTH_TOKEN_ENV_NAME = "GITHUB_OAUTH"
+    }
+
+    private val version by option("--ref", help = "the release ref triggering this dependency bump").convert { ref ->
+        if (!ref.startsWith(REF_PREFIX)) {
+            fail("Ref '$ref' is not a valid release ref")
+        }
+        ref.removePrefix(REF_PREFIX)
+    }.required()
+
+    private val key by option(help = "the key in gradle.properties to modify")
+        .required()
+
+    private val repositories by option(help = "the comma-separated list of repository names to modify")
+        .split(",")
+        .required()
+
+    private val repoOwner by option(help = "the owner of the repositories to modify")
+        .required()
+
+    private val upstreamOwner by option(help = "the owner of the repositories to send pull requests to")
+        .required()
+
+    private val reviewers by option(help = "the comma-separated list of reviewers (prefixed with 'team:' for a team) for the pull request")
+        .convert { convertReviewersArg(it) }
+        .default(Reviewers())
+
+    private val oauthToken by lazy {
+        val oauthToken = System.getenv(GITHUB_OAUTH_TOKEN_ENV_NAME)
+        if (oauthToken == null) {
+            throw UsageError("A GitHub OAuth token must be provided in the $GITHUB_OAUTH_TOKEN_ENV_NAME environment variable")
+        }
+        oauthToken
+    }
+
+    override fun run() {
+        val repoParent = createTempDirectory()
+
+        val executor = Executors.newCachedThreadPool()
+        val results = mutableMapOf<String, Future<*>>()
+        repositories.forEach { repoName ->
+            results[repoName] = executor.submit {
+                val branchName = "autobump-$key"
+                createModifiedBranch(repoParent, repoName, branchName)
+                createPullRequest(repoName, branchName)
+            }
+        }
+
+        executor.shutdown()
+        executor.awaitTermination(10, TimeUnit.MINUTES)
+
+        val failures = waitForResults(results)
+
+        if (failures) {
+            exitProcess(1)
+        }
+    }
+
+    private fun createModifiedBranch(
+        repoParent: Path,
+        repoName: String,
+        branchName: String
+    ) {
+        val credentialsProvider =
+            UsernamePasswordCredentialsProvider("ignored-username", oauthToken)
+
+        val repoRoot = repoParent.resolve(repoName)
+        val upstreamUri = "https://github.com/$upstreamOwner/$repoName"
+        logger.info { "Cloning $upstreamUri to $repoRoot" }
+        val git = Git.cloneRepository()
+            .setCredentialsProvider(credentialsProvider)
+            .setURI(upstreamUri)
+            .setDirectory(repoRoot.toFile())
+            .call()
+        val gradlePropsFile = repoRoot.resolve("gradle.properties")
+        updatePropertiesFile(gradlePropsFile, repoName)
+        if (git.branchList().call().map { it.name }.contains(branchName)) {
+            git.branchDelete().setBranchNames(branchName).setForce(true).call()
+        }
+        git.checkout().setName(branchName).setCreateBranch(true).call()
+        git.commit().setMessage("chore(dependencies): Autobump $key").setAll(true).call()
+        val userUri = "https://github.com/$repoOwner/$repoName"
+        git.remoteAdd().setName("userFork").setUri(URIish(userUri)).call()
+        logger.info { "Force-pushing changes to $userUri" }
+        git.push()
+            .setCredentialsProvider(credentialsProvider)
+            .setRemote("userFork")
+            .setRefSpecs(RefSpec("$branchName:$branchName"))
+            .setForce(true)
+            .call()
+    }
+
+    private fun updatePropertiesFile(gradlePropsFile: Path, repoName: String) {
+        val gradleProps = FileInputStream(gradlePropsFile.toFile()).use { fis ->
+            OrderedPropertiesBuilder()
+                .withOrdering(String.CASE_INSENSITIVE_ORDER)
+                .withSuppressDateInComment(true)
+                .build()
+                .apply { load(fis) }
+        }
+        if (!gradleProps.containsProperty(key)) {
+            throw IllegalArgumentException("Couldn't locate key $key in $repoName's gradle.properties file")
+        }
+        if (gradleProps.getProperty(key) == version) {
+            throw IllegalArgumentException("$repoName's $key is already set to $version")
+        }
+        gradleProps.setProperty(key, version)
+        FileOutputStream(gradlePropsFile.toFile()).use { fos ->
+            gradleProps.store(fos, /* comments= */ null)
+        }
+    }
+
+    private fun createPullRequest(repoName: String, branchName: String) {
+        val github = GitHubBuilder().withOAuthToken(oauthToken).build()
+        val githubRepo = github.getRepository("$upstreamOwner/$repoName")
+
+        // If there's already an existing PR, we can just reuse it... we already force-pushed the branch, so it'll
+        // automatically update.
+        val existingPr = githubRepo.getPullRequests(GHIssueState.OPEN)
+            .firstOrNull { pr -> pr.labels.map { label -> label.name }.contains(branchName) }
+
+        if (existingPr != null) {
+            logger.info { "Found existing PR for repo $repoName: ${existingPr.htmlUrl}" }
+            return
+        }
+
+        logger.info { "Creating pull request for repo $repoName" }
+        val pr = githubRepo.createPullRequest(
+            /* title= */"chore(dependencies): Autobump $key",
+            /* head= */ "$repoOwner:$branchName",
+            /* base= */ "master",
+            /* body= */ ""
+        )
+
+        pr.addLabels(branchName)
+
+        if (reviewers.users.isNotEmpty()) {
+            pr.requestReviewers(reviewers.users.map { github.getUser(it) })
+        }
+        if (reviewers.teams.isNotEmpty()) {
+            val upstreamOrg = github.getOrganization(upstreamOwner)
+            pr.requestTeamReviewers(reviewers.teams.map { upstreamOrg.getTeamByName(it) })
+        }
+
+        logger.info { "Created pull request for $repoName: ${pr.htmlUrl}" }
+    }
+
+    data class Reviewers(val users: Set<String> = setOf(), val teams: Set<String> = setOf())
+    private fun convertReviewersArg(reviewersString: String): Reviewers {
+        val reviewers = reviewersString.split(',').map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+        val teams = reviewers.filter { it.startsWith("team:") }.toSet()
+        val users = reviewers - teams
+        return Reviewers(users, teams.map { it.removePrefix("team:") }.toSet())
+    }
+
+    private fun waitForResults(results: MutableMap<String, Future<*>>): Boolean {
+        var failures = false
+        results
+            .forEach { result ->
+                try {
+                    result.value.get()
+                } catch (e: ExecutionException) {
+                    logger.error(e) { "Exception updating repository ${result.key}" }
+                    failures = true
+                }
+            }
+        return failures
+    }
+
+    private fun createTempDirectory(): Path {
+        val repoParent = Files.createTempDirectory("bumpdeps-git-")
+        Runtime.getRuntime().addShutdownHook(object : Thread() {
+            override fun run() {
+                repoParent.toFile().deleteRecursively()
+            }
+        })
+        return repoParent
+    }
+}
+
+fun main(args: Array<String>) {
+    BumpDeps().main(args)
+}


### PR DESCRIPTION
This is a GHA replacement for the `bumpDependencies` gradle task.

It has a few advantages:
* Since it's not part of the plugin anymore, we can also use it in the `spinnaker-gradle-project` repository, to keep the gradle plugin consistent across repos
* It uses the [java-ordered-properties](https://github.com/etiennestuder/java-ordered-properties) library so that the `gradle.properties` files aren't constantly getting reordered on every commit
* A GHA is a more logical place to keep this code

There's a `README` already in the repo you can look at because I had to put something there; apparently you can't send a PR to an empty repo. But I wanted to get the actual code reviewed.