### PR TITLE
fix(bumpdeps): groupId and artifactId docker args need to be kebab-case; --group-id and --artifact-id

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
   - ${{ inputs.reviewers }}
   - '--maven-repository-url'
   - ${{ inputs.mavenRepositoryUrl }}
-  - '--groupId'
+  - '--group-id'
   - ${{ inputs.groupId }}
-  - '--artifactId'
+  - '--artifact-id'
   - ${{ inputs.artifactId }}


### PR DESCRIPTION
Seems like kebab-case is the default format the Clikt library expects.