### PR TITLE
chore(build): bump versions to address snyk vulnerabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,8 +14,8 @@ dependencies {
     implementation("com.github.ajalt:clikt:2.7.1")
     implementation("com.squareup.okhttp3:okhttp:4.7.2")
     implementation("io.github.microutils:kotlin-logging:1.7.9")
-    implementation("org.eclipse.jgit:org.eclipse.jgit:5.7.0.202003110725-r")
-    implementation("org.kohsuke:github-api:1.112")
+    implementation("org.eclipse.jgit:org.eclipse.jgit:5.8.0.202006091008-r")
+    implementation("org.kohsuke:github-api:1.129")
 
     runtimeOnly("org.slf4j:slf4j-simple:1.7.30")
 


### PR DESCRIPTION
We ran snyk internally and it popped up these issues:

* 1/6: XML External Entity (XXE) Injection [High Severity]
  * Via: project@unspecified => org.kohsuke:github-api@1.112 => com.fasterxml.jackson.core:jackson-databind@2.10.2
  * Fixed in: com.fasterxml.jackson.core:jackson-databind, 2.6.7.4, 2.9.10.7, 2.10.5.1
  * Fixable by upgrade: org.kohsuke:github-api@1.123=>com.fasterxml.jackson.core:jackson-databind@2.12.1
* 2/6: Directory Traversal [Medium Severity]
  * Via: project@unspecified => org.kohsuke:github-api@1.112 => commons-io:commons-io@2.4
  * Fixed in: commons-io:commons-io, 2.7
  * Fixable by upgrade: org.kohsuke:github-api@1.129=>commons-io:commons-io@2.8.0
* 3/6: Information Exposure [Low Severity]
  * Via: project@unspecified => org.junit.platform:junit-platform-runner@1.6.2 => junit:junit@4.13
  * Fixed in: junit:junit, 4.13.1
* 4/6: Timing Attack [Medium Severity]
  * Via: project@unspecified => org.eclipse.jgit:org.eclipse.jgit@5.7.0.202003110725-r => org.bouncycastle:bcprov-jdk15on@1.64
  * Fixed in: org.bouncycastle:bcprov-jdk15on, 1.66
  * Fixable by upgrade: org.eclipse.jgit:org.eclipse.jgit@5.8.0.202006091008-r
* 5/6: Timing Attack [Medium Severity]
  * Via: project@unspecified => org.eclipse.jgit:org.eclipse.jgit@5.7.0.202003110725-r => org.bouncycastle:bcpg-jdk15on@1.64 => org.bouncycastle:bcprov-jdk15on@1.64
  * Fixed in: org.bouncycastle:bcprov-jdk15on, 1.66
  * Fixable by upgrade: org.eclipse.jgit:org.eclipse.jgit@5.8.0.202006091008-r
* 6/6: Timing Attack [Medium Severity]
  * Via: project@unspecified => org.eclipse.jgit:org.eclipse.jgit@5.7.0.202003110725-r => org.bouncycastle:bcpkix-jdk15on@1.64 => org.bouncycastle:bcprov-jdk15on@1.64
  * Fixed in: org.bouncycastle:bcprov-jdk15on, 1.66
  * Fixable by upgrade: org.eclipse.jgit:org.eclipse.jgit@5.8.0.202006091008-r

This PR removes them.