### PR TITLE
fix(gha): adding baseBranch to bumpDeps GHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   ref:
     description: 'the release ref triggering this dependency bump'
     required: true
+  baseBranch:
+      description: 'the branch to update'
+      required: true
   key:
     description: 'the key in gradle.properties to modify'
     required: true


### PR DESCRIPTION
https://github.com/spinnaker/kork/runs/3306815678 failed to update the branch due to `baseBranch` being an invalid input