### PR TITLE
chore(build): replace application.setMainClassName with application.mainClass.set

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ tasks.withType<Test> {
 }
 
 application {
-    mainClassName = "io.spinnaker.bumpdeps.MainKt"
+    mainClass.set("io.spinnaker.bumpdeps.MainKt")
 }
 
 ktlint {


### PR DESCRIPTION
to remove warning:
```
$ ./gradlew --warning-mode=fail build
Starting a Gradle Daemon (subsequent builds will be faster)

> Configure project :
The JavaApplication.setMainClassName(String) method has been deprecated. This is scheduled to be removed in Gradle 8.0. Use #getMainClass().set(...) instead. See https://docs.gradle.org/6.7/dsl/org.gradle.api.plugins.JavaApplication.html#org.gradle.api.plugins.JavaApplication:mainClass for more details.
        at Build_gradle$4.execute(build.gradle.kts:37)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

FAILURE: Build failed with an exception.

* What went wrong: Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0

* Try: Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 54s
11 actionable tasks: 9 executed, 2 up-to-date
```