### PR TITLE
chore(build): remove jcenter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
because it no longer exists, and to remove this deprecation warning:
```
The RepositoryHandler.jcenter() method has been deprecated. This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's sunset in February 2021. Use mavenCentral() instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.6.1/userguide/upgrading_version_6.html#jcenter_deprecation
        at Build_gradle$1.invoke(build.gradle.kts:10)
```